### PR TITLE
chore: align EnvironmentFile path with standardized env file

### DIFF
--- a/deploy/systemd/webitel-fts.service
+++ b/deploy/systemd/webitel-fts.service
@@ -4,7 +4,7 @@ After=network.target consul.service rabbitmq-server.service postgresql.service
 [Service]
 Type=simple
 Restart=always
-EnvironmentFile=/etc/default/webitel-fts.env
+EnvironmentFile=/etc/default/webitel-fts
 TimeoutStartSec=0
 ExecStart=/usr/local/bin/webitel-fts server
 


### PR DESCRIPTION
Drops the `.env` suffix: `EnvironmentFile=/etc/default/webitel-fts` to match the standardized package dst (`/etc/default/webitel-fts`). Prevents a fresh-install mismatch once the reusable-configs standardization lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)