### PR TITLE
feat(deb): read index mapping from /usr/share/webitel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ OPENSEARCH_ADDR=https://127.0.0.1:9200
 PUBSUB=amqp://webitel:webitel@127.0.0.1:5672
 DATA_SOURCE=postgres://opensips:webitel@127.0.0.1:5432/webitel?sslmode=disable
 CONSUL=127.0.0.1:8500
+
+INDEX_TEMPLATE=/usr/share/webitel/webitel-fts/mapping/cases.json


### PR DESCRIPTION
Set `INDEX_TEMPLATE` to the packaged `/usr/share/webitel/webitel-fts/mapping/cases.json` (read-only).

> Depends on the matching reusable-configs `sync.yml` change (ships the dir under `/usr/share/webitel`). Until that merges + re-syncs, the env points at a not-yet-shipped path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)