### PR TITLE
ref(deploy): backport systemd hardening to v26.04

### DIFF
--- a/.github/workflows/pull-request-deliver.yml
+++ b/.github/workflows/pull-request-deliver.yml
@@ -16,6 +16,10 @@ jobs:
   version:
     name: Version
     uses: webitel/reusable-workflows/.github/workflows/_version.yml@v2
+    permissions:
+      contents: read
+      id-token: write
+
     if: |
       github.event.workflow_run.head_repository.fork == false &&
       github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -52,7 +52,8 @@ jobs:
       package-description: ${{ github.event.repository.description }}
       package-contents: |
         src=deploy/systemd/webitel-fts.service dst=/etc/systemd/system/webitel-fts.service type=config
-        src=.env.example dst=/etc/default/webitel-fts type=config
+        src=mapping/ dst=/usr/share/webitel/webitel-fts/mapping
+        src=.env.example dst=/etc/default/webitel-fts type=config mode=0640
         
 
       scripts: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -60,7 +60,8 @@ jobs:
       package-description: ${{ github.event.repository.description }}
       package-contents: |
         src=deploy/systemd/webitel-fts.service dst=/etc/systemd/system/webitel-fts.service type=config
-        src=.env.example dst=/etc/default/webitel-fts type=config
+        src=mapping/ dst=/usr/share/webitel/webitel-fts/mapping
+        src=.env.example dst=/etc/default/webitel-fts type=config mode=0640
         
 
       package-depends: 

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ Thumbs.db
 .env.*
 *.env
 !.env.example
-!.env.otel.example
+!.env.*.example
 !.env.sample
 !example.env
 env

--- a/deploy/debian/postinst.sh
+++ b/deploy/debian/postinst.sh
@@ -49,7 +49,7 @@ create_user() {
 # and run under `set -e`: a failing hook aborts the install, which is the
 # correct behaviour when e.g. a required certificate cannot be generated.
 run_postinst_hooks() {
-    local hook_dir="/usr/lib/$DPKG_MAINTSCRIPT_PACKAGE/deb/postinst.d"
+    local hook_dir="/usr/lib/webitel/$DPKG_MAINTSCRIPT_PACKAGE/deb/postinst.d"
     [ -d "$hook_dir" ] || return 0
 
     local hook

--- a/deploy/systemd/webitel-fts.service
+++ b/deploy/systemd/webitel-fts.service
@@ -1,12 +1,70 @@
 [Unit]
+Description=Webitel FTS
 After=network.target consul.service rabbitmq-server.service postgresql.service
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 [Service]
 Type=simple
-Restart=always
+User=webitel
+Group=webitel
+LogsDirectory=webitel
+
 EnvironmentFile=/etc/default/webitel-fts
-TimeoutStartSec=0
+EnvironmentFile=-/etc/default/webitel-otel
+EnvironmentFile=-/etc/default/webitel
 ExecStart=/usr/local/bin/webitel-fts server
 
+Restart=on-failure
+RestartSec=5
+KillMode=mixed
+KillSignal=SIGTERM
+TimeoutStartSec=0
+TimeoutStopSec=30
+LimitNOFILE=64000
+LimitNPROC=4096
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=webitel-fts
+
+# Filesystem isolation
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+NoExecPaths=/
+ExecPaths=/usr/local/bin/webitel-fts
+
+# Process isolation
+PrivateDevices=yes
+PrivateUsers=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectProc=invisible
+ProcSubset=pid
+NoNewPrivileges=yes
+PrivateMounts=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RemoveIPC=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+ProtectClock=yes
+ProtectHostname=yes
+MemoryDenyWriteExecute=yes
+SystemCallArchitectures=native
+UMask=0077
+
+# Capabilities & syscalls
+CapabilityBoundingSet=
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged
+SystemCallFilter=~@resources
+SystemCallFilter=~@obsolete
+SystemCallErrorNumber=EPERM
+
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target


### PR DESCRIPTION
Backports this cycle's deployment work to the `v26.04` release branch via cherry-pick (deploy/ + env examples + .gitignore + workflow package-contents only).

- standardized & hardened systemd unit(s)
- config moved to `/etc/default/` env-file layering
- `LogsDirectory=webitel`
- directory provisioning via postinst drop-in hooks where needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)